### PR TITLE
feat(worker-compat): adds explicit path as module_root to bindings call

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,12 @@
   limitations under the License.
 */
 
-const addon = require('bindings')('grandiose');
+const path = require('path');
+
+const addon = require('bindings')({
+  bindings: 'grandiose',
+  module_root: path.resolve(__dirname)
+});
 
 try {
   const SegfaultHandler = require('segfault-handler');


### PR DESCRIPTION
A use-case of grandiose could be to use the incoming video frames in a Worker within an environment
such as electron with webpack. Loading a Worker with webpack creates an eval statement which breaks
bindings' module path resolver. Passing the module_root option with the full path solves this issue.